### PR TITLE
Fix appcast stanza is deprecated warning message

### DIFF
--- a/Casks/xdebug-toggler.rb
+++ b/Casks/xdebug-toggler.rb
@@ -3,9 +3,13 @@ cask "xdebug-toggler" do
    sha256 "7c21a401a49da467515b1e693f9551378a1fba717fba423cfb720c9ca3d37ed6"
 
    url "https://github.com/deligoez/xDebug-Toggler/releases/download/#{version}/xDebugToggler.dmg"
-   appcast "https://github.com/deligoez/xDebug-Toggler/releases.atom"
    name "xDebugToggler"
    homepage "https://github.com/deligoez/xDebug-Toggler"
+
+   livecheck do
+      url :url
+      strategy :github_latest
+   end
 
    app "xDebugToggler.app"
  end


### PR DESCRIPTION
```
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
Please report this issue to the deligoez/cask tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/deligoez/homebrew-cask/Casks/xdebug-toggler.rb:6
```